### PR TITLE
feat: implement balance netting (相殺) functionality for graph and list display

### DIFF
--- a/components/graphs/BalanceList.tsx
+++ b/components/graphs/BalanceList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { netBalances } from "@/lib/utils/balance";
 
 export type BalanceWithUser = {
   userFrom: string;
@@ -27,13 +28,16 @@ export default function BalanceList({
   balances,
   currentUserId,
 }: BalanceListProps) {
-  // 払う必要がある残高
-  const toPay = balances.filter(
+  // ★ 相殺処理を追加
+  const netBalanceData = netBalances(balances);
+
+  // 払う必要がある残高（相殺後）
+  const toPay = netBalanceData.filter(
     (balance) => balance.userFrom === currentUserId && balance.amount > 0
   );
 
-  // 貰える残高
-  const toReceive = balances.filter(
+  // 貰える残高（相殺後）
+  const toReceive = netBalanceData.filter(
     (balance) => balance.userTo === currentUserId && balance.amount > 0
   );
 

--- a/lib/utils/graph.ts
+++ b/lib/utils/graph.ts
@@ -1,5 +1,6 @@
 import dagre from "@dagrejs/dagre";
 import type { Node, Edge } from "@xyflow/react";
+import { netBalances } from "./balance";
 
 export type Balance = {
   userFrom: string;
@@ -38,6 +39,9 @@ export function balancesToGraph(
   users: User[],
   currentUserId?: string
 ): { nodes: Node<UserNodeData>[]; edges: Edge<DebtEdgeData>[] } {
+  // ★ 相殺処理を追加
+  const netBalanceData = netBalances(balances);
+
   // 1. 全メンバーのノードを作成
   const nodes: Node<UserNodeData>[] = users.map((user) => ({
     id: user.id,
@@ -50,8 +54,8 @@ export function balancesToGraph(
     },
   }));
 
-  // 2. 残高があるエッジのみ作成
-  const edges: Edge<DebtEdgeData>[] = balances
+  // 2. 残高があるエッジのみ作成（相殺後のデータを使用）
+  const edges: Edge<DebtEdgeData>[] = netBalanceData
     .filter((balance) => balance.amount > 0)
     .map((balance) => ({
       id: `${balance.userFrom}-${balance.userTo}`,


### PR DESCRIPTION
feat: implement balance netting (相殺) functionality for graph and list display

## Copilot AI Review Comments (Deferred for Future Issues)

1. **Performance Optimization**: The `netBalances` function has O(n²) complexity due to the `find()` operation inside the loop. Consider using a Map to store balances by their userFrom-userTo key for O(1) lookups, reducing overall complexity to O(n).

2. **TypeScript Type Safety**: When spreading the `reverse` object, TypeScript may not guarantee that `reverse` matches type T since it comes from a `find()` that could theoretically return undefined. Consider explicitly typing or re-constructing the object with known T properties, e.g., `result.push({ ...reverse, amount: -diff } as T);`

These improvements will be addressed in separate issues to maintain focus on core functionality.