### PR TITLE
fix(auth): use singleton Prisma instance and add debug mode

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -2,9 +2,7 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/lib/prisma";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -20,6 +18,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   pages: {
     signIn: "/auth/signin",
   },
+  debug: process.env.NODE_ENV === "development",
   callbacks: {
     async jwt({ token, user }) {
       if (user) {


### PR DESCRIPTION
- Use shared prisma instance from lib/prisma.ts instead of creating new client
- Add debug mode for development environment
- Fixes potential connection pooling issues with NextAuth adapter